### PR TITLE
Support Application load balancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This terraform module creates a Docker Swarm cluster using AWS EC2 instances. It
 |------|-------------|------|---------|:-----:|
 | ami | Ubuntu Server 18.04 LTS AMI | `string` | `"ami-09a4a9ce71ff3f20b"` | no |
 | availability\_zone | The availability zone in which to create EC2 instances | `string` | `"ap-southeast-1a"` | no |
+| certificate\_arn | ARN of the default SSL certificate on HTTPS listener | `any` | n/a | yes |
 | connection\_timeout | Timeout for connection to servers | `string` | `"2m"` | no |
 | eip\_allocation\_id | The allocation ID of the Elastic IP address | `any` | n/a | yes |
 | enable\_efs | Set to true in order to enable EFS | `bool` | `false` | no |
@@ -29,6 +30,7 @@ This terraform module creates a Docker Swarm cluster using AWS EC2 instances. It
 | ssh\_public\_keys | SSH public keys to add to instances | `string` | `""` | no |
 | ssh\_user | User for logging into nodes (ansible) | `string` | `"ubuntu"` | no |
 | subnet\_main\_cidr | n/a | `string` | `"192.168.0.0/24"` | no |
+| subnets | A map of availability zones to CIDR blocks, which will be set up as subnets. | `map(string)` | <pre>{<br>  "ap-southeast-1a": "192.168.0.0/26",<br>  "ap-southeast-1b": "192.168.0.64/26",<br>  "ap-southeast-1c": "192.168.0.128/26"<br>}</pre> | no |
 | swarm\_manager\_count | Number of manager nodes | `number` | `1` | no |
 | swarm\_manager\_name | Name to use for naming manager nodes | `string` | `"manager"` | no |
 | swarm\_name | n/a | `any` | n/a | yes |
@@ -42,6 +44,7 @@ This terraform module creates a Docker Swarm cluster using AWS EC2 instances. It
 | Name | Description |
 |------|-------------|
 | efs\_dns\_name | DNS name of the provisioned AWS EFS |
+| loadbalancer | DNS name of the loadbalancer |
 | swarm\_manager\_ips | The manager nodes public ipv4 adresses |
 | swarm\_manager\_ips\_private | The manager nodes private ipv4 adresses |
 | swarm\_worker\_ips | The worker nodes public ipv4 adresses |

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ This terraform module creates a Docker Swarm cluster using AWS EC2 instances. It
 | Name | Description |
 |------|-------------|
 | efs\_dns\_name | DNS name of the provisioned AWS EFS |
+| global\_accelerator\_dns\_name | DNS name of the AWS Global Accelerator |
+| global\_accelerator\_static\_ip\_addresses | Static IP addresses associated with the AWS Global Accelerator |
 | loadbalancer\_dns\_name | DNS name of the loadbalancer |
 | swarm\_manager\_ips | The manager nodes public ipv4 adresses |
 | swarm\_manager\_ips\_private | The manager nodes private ipv4 adresses |

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ This terraform module creates a Docker Swarm cluster using AWS EC2 instances. It
 | certificate\_arn | ARN of the default SSL certificate on HTTPS listener | `any` | n/a | yes |
 | connection\_timeout | Timeout for connection to servers | `string` | `"5m"` | no |
 | eip\_allocation\_id | The allocation ID of the Elastic IP address | `any` | n/a | yes |
-| enable\_efs | Set to true in order to enable EFS | `bool` | `false` | no |
-| enable\_gluster | Set to true in order to enable gluster | `bool` | `false` | no |
+| enable\_accelerator | Set to true to enable AWS Global Accelerator | `bool` | `false` | no |
+| enable\_efs | Set to true to enable EFS | `bool` | `false` | no |
+| enable\_gluster | Set to true to enable gluster | `bool` | `false` | no |
 | env | The environment of the current deployment | `any` | n/a | yes |
 | gluster\_volume\_size | Size of the gluster volume in GiBs. | `number` | `1` | no |
 | key\_pair\_name | The name for the key pair | `any` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -16,20 +16,18 @@ This terraform module creates a Docker Swarm cluster using AWS EC2 instances. It
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
 | ami | Ubuntu Server 18.04 LTS AMI | `string` | `"ami-09a4a9ce71ff3f20b"` | no |
-| availability\_zone | The availability zone in which to create EC2 instances | `string` | `"ap-southeast-1a"` | no |
 | certificate\_arn | ARN of the default SSL certificate on HTTPS listener | `any` | n/a | yes |
-| connection\_timeout | Timeout for connection to servers | `string` | `"2m"` | no |
+| connection\_timeout | Timeout for connection to servers | `string` | `"5m"` | no |
 | eip\_allocation\_id | The allocation ID of the Elastic IP address | `any` | n/a | yes |
 | enable\_efs | Set to true in order to enable EFS | `bool` | `false` | no |
 | enable\_gluster | Set to true in order to enable gluster | `bool` | `false` | no |
 | env | The environment of the current deployment | `any` | n/a | yes |
-| gluster\_volume\_size | Size of the gluster volume | `number` | `1` | no |
+| gluster\_volume\_size | Size of the gluster volume in GiBs. | `number` | `1` | no |
 | key\_pair\_name | The name for the key pair | `any` | n/a | yes |
 | key\_path | SSH public key path for key pair | `string` | `"~/.ssh/id_rsa.pub"` | no |
 | manager\_instance\_type | Manager instance type | `string` | `"t3a.large"` | no |
 | ssh\_public\_keys | SSH public keys to add to instances | `string` | `""` | no |
 | ssh\_user | User for logging into nodes (ansible) | `string` | `"ubuntu"` | no |
-| subnet\_main\_cidr | n/a | `string` | `"192.168.0.0/24"` | no |
 | subnets | A map of availability zones to CIDR blocks, which will be set up as subnets. | `map(string)` | <pre>{<br>  "ap-southeast-1a": "192.168.0.0/26",<br>  "ap-southeast-1b": "192.168.0.64/26",<br>  "ap-southeast-1c": "192.168.0.128/26"<br>}</pre> | no |
 | swarm\_manager\_count | Number of manager nodes | `number` | `1` | no |
 | swarm\_manager\_name | Name to use for naming manager nodes | `string` | `"manager"` | no |
@@ -44,7 +42,7 @@ This terraform module creates a Docker Swarm cluster using AWS EC2 instances. It
 | Name | Description |
 |------|-------------|
 | efs\_dns\_name | DNS name of the provisioned AWS EFS |
-| loadbalancer | DNS name of the loadbalancer |
+| loadbalancer\_dns\_name | DNS name of the loadbalancer |
 | swarm\_manager\_ips | The manager nodes public ipv4 adresses |
 | swarm\_manager\_ips\_private | The manager nodes private ipv4 adresses |
 | swarm\_worker\_ips | The worker nodes public ipv4 adresses |

--- a/alb.tf
+++ b/alb.tf
@@ -1,0 +1,91 @@
+resource "aws_lb" "web" {
+  name               = "${var.swarm_name}-lb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.lb.id]
+  subnets            = aws_subnet.main.*.id
+
+  tags = {
+    Environment = var.env
+  }
+}
+
+resource "aws_security_group" "lb" {
+  name   = "${var.swarm_name}-lb-security-group"
+  vpc_id = aws_vpc.main.id
+
+  ingress {
+    from_port        = 80
+    to_port          = 80
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    from_port        = 443
+    to_port          = 443
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+}
+
+resource "aws_lb_target_group" "web" {
+  name        = "${var.swarm_name}-lb-tg"
+  port        = 80
+  protocol    = "HTTP"
+  target_type = "instance"
+  vpc_id      = aws_vpc.main.id
+
+  health_check {
+    interval            = "30"
+    path                = "/ping"
+    port                = 80
+    protocol            = "HTTP"
+    timeout             = "5"
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    matcher             = "200"
+  }
+
+  tags = {
+    Environment = var.env
+  }
+}
+
+resource "aws_lb_target_group_attachment" "web" {
+  count            = var.swarm_manager_count
+  target_group_arn = aws_lb_target_group.web.arn
+  target_id        = element(aws_instance.manager.*.id, count.index)
+  port             = 80
+}
+
+resource "aws_lb_listener" "web_https" {
+  load_balancer_arn = aws_lb.web.arn
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.web.arn
+  }
+}
+
+resource "aws_lb_listener" "web_http" {
+  load_balancer_arn = aws_lb.web.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}

--- a/alb.tf
+++ b/alb.tf
@@ -14,6 +14,13 @@ resource "aws_security_group" "lb" {
   name   = "${var.swarm_name}-lb-security-group"
   vpc_id = aws_vpc.main.id
 
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   ingress {
     from_port        = 80
     to_port          = 80

--- a/main.tf
+++ b/main.tf
@@ -82,10 +82,10 @@ resource "aws_route_table_association" "route" {
   route_table_id = aws_route_table.public_route_table.id
 }
 
-resource "aws_ebs_volume" "ebs_volume" {
-  availability_zone = aws_instance.manager[0].availability_zone
+resource "aws_ebs_volume" "gluster_ebs_volume" {
+  availability_zone = element(aws_instance.manager.*.availability_zone, count.index)
   count             = var.enable_gluster ? var.swarm_manager_count : 0
-  size              = 1
+  size              = var.gluster_volume_size
 }
 
 resource "aws_volume_attachment" "ebs_attachment" {
@@ -93,7 +93,7 @@ resource "aws_volume_attachment" "ebs_attachment" {
   device_name  = "/dev/xvdf"
   force_detach = true
   instance_id  = element(aws_instance.manager.*.id, count.index)
-  volume_id    = element(aws_ebs_volume.ebs_volume.*.id, count.index)
+  volume_id    = element(aws_ebs_volume.gluster_ebs_volume.*.id, count.index)
 }
 
 resource "aws_efs_file_system" "main" {

--- a/main.tf
+++ b/main.tf
@@ -26,11 +26,11 @@ resource "aws_vpc" "main" {
 }
 
 resource "aws_subnet" "main" {
-  count             = length(var.subnets)
-  availability_zone = element(keys(var.subnets), count.index)
-  cidr_block        = element(values(var.subnets), count.index)
+  count                   = length(var.subnets)
+  availability_zone       = element(keys(var.subnets), count.index)
+  cidr_block              = element(values(var.subnets), count.index)
   map_public_ip_on_launch = true
-  vpc_id            = aws_vpc.main.id
+  vpc_id                  = aws_vpc.main.id
 
   tags = {
     Name = "${var.swarm_name}-subnet"

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,7 +3,7 @@ output "efs_dns_name" {
   value       = aws_efs_file_system.main.*.dns_name
 }
 
-output "loadbalancer" {
+output "loadbalancer_dns_name" {
   description = "DNS name of the loadbalancer"
   value       = aws_lb.web.dns_name
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,16 @@ output "efs_dns_name" {
   value       = aws_efs_file_system.main.*.dns_name
 }
 
+output "global_accelerator_dns_name" {
+  description = "DNS name of the AWS Global Accelerator"
+  value       = aws_globalaccelerator_accelerator.web.*.dns_name
+}
+
+output "global_accelerator_static_ip_addresses" {
+  description = "Static IP addresses associated with the AWS Global Accelerator"
+  value       = aws_globalaccelerator_accelerator.web.*.ip_sets
+}
+
 output "loadbalancer_dns_name" {
   description = "DNS name of the loadbalancer"
   value       = aws_lb.web.dns_name

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,11 @@
 output "efs_dns_name" {
   description = "DNS name of the provisioned AWS EFS"
-  value       = aws_efs_file_system.main[0].dns_name
+  value       = aws_efs_file_system.main.*.dns_name
+}
+
+output "loadbalancer" {
+  description = "DNS name of the loadbalancer"
+  value       = aws_lb.web.dns_name
 }
 
 output "swarm_manager_ips" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "efs_dns_name" {
   description = "DNS name of the provisioned AWS EFS"
-  value       = aws_efs_mount_target.main.*.dns_name
+  value       = aws_efs_file_system.main[0].dns_name
 }
 
 output "swarm_manager_ips" {

--- a/variables.tf
+++ b/variables.tf
@@ -62,6 +62,17 @@ variable "subnet_main_cidr" {
   default = "192.168.0.0/24"
 }
 
+variable "subnets" {
+  description = "A map of availability zones to CIDR blocks, which will be set up as subnets."
+  type = map(string)
+
+  default = {
+    ap-southeast-1a = "192.168.0.0/26"
+    ap-southeast-1b = "192.168.0.64/26"
+    ap-southeast-1c = "192.168.0.128/26"
+  }
+}
+
 variable "swarm_manager_count" {
   description = "Number of manager nodes"
   default     = 1

--- a/variables.tf
+++ b/variables.tf
@@ -101,7 +101,7 @@ variable "worker_instance_type" {
 //-------------------------------------------------------------------
 
 variable "enable_efs" {
-  description = "Set to true in order to enable EFS"
+  description = "Set to true to enable EFS"
   default     = false
 }
 
@@ -111,12 +111,17 @@ variable "certificate_arn" {
   description = "ARN of the default SSL certificate on HTTPS listener"
 }
 
+variable "enable_accelerator" {
+  description = "Set to true to enable AWS Global Accelerator"
+  default     = false
+}
+
 //-------------------------------------------------------------------
 // Gluster settings
 //-------------------------------------------------------------------
 
 variable "enable_gluster" {
-  description = "Set to true in order to enable gluster"
+  description = "Set to true to enable gluster"
   default     = false
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,7 @@ variable "eip_allocation_id" {
 
 variable "connection_timeout" {
   description = "Timeout for connection to servers"
-  default     = "2m"
+  default     = "5m"
 }
 
 variable "key_pair_name" {
@@ -48,18 +48,9 @@ variable "ami" {
   default     = "ami-09a4a9ce71ff3f20b"
 }
 
-variable "availability_zone" {
-  description = "The availability zone in which to create EC2 instances"
-  default     = "ap-southeast-1a"
-}
-
 variable "manager_instance_type" {
   description = "Manager instance type"
   default     = "t3a.large"
-}
-
-variable "subnet_main_cidr" {
-  default = "192.168.0.0/24"
 }
 
 variable "subnets" {
@@ -130,6 +121,6 @@ variable "enable_gluster" {
 }
 
 variable "gluster_volume_size" {
-  description = "Size of the gluster volume"
+  description = "Size of the gluster volume in GiBs."
   default     = 1
 }

--- a/variables.tf
+++ b/variables.tf
@@ -64,7 +64,7 @@ variable "subnet_main_cidr" {
 
 variable "subnets" {
   description = "A map of availability zones to CIDR blocks, which will be set up as subnets."
-  type = map(string)
+  type        = map(string)
 
   default = {
     ap-southeast-1a = "192.168.0.0/26"
@@ -112,6 +112,12 @@ variable "worker_instance_type" {
 variable "enable_efs" {
   description = "Set to true in order to enable EFS"
   default     = false
+}
+
+// Loadbalancer settings
+
+variable "certificate_arn" {
+  description = "ARN of the default SSL certificate on HTTPS listener"
 }
 
 //-------------------------------------------------------------------


### PR DESCRIPTION
- Supports provisioning instances on multiple availability zones with each AZ having one subnet. If no. of instances > no. of subnets, then instances are provisioned in each subnet, then started back from first subnet on list.
- Adds support for provisioning Application load balancer in front of swarm.
- Adds support for provisioning AWS global accelerator with flag `enable_accelerator`