### PR TITLE
Private ip on Ansible inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ This terraform module creates a Docker Swarm cluster using AWS EC2 instances. It
 
 | Name | Description |
 |------|-------------|
+| ansible\_inventory | Content of Ansible inventory |
 | efs\_dns\_name | DNS name of the provisioned AWS EFS |
-| swarm\_manager\_ips | The manager nodes public ipv4 adresses |
-| swarm\_manager\_ips\_private | The manager nodes private ipv4 adresses |
-| swarm\_worker\_ips | The worker nodes public ipv4 adresses |
-| swarm\_worker\_ips\_private | The worker nodes private ipv4 adresses |
+| swarm\_manager\_private\_ips | The manager nodes private ipv4 adresses |
+| swarm\_manager\_public\_ips | The manager nodes public ipv4 adresses |
+| swarm\_worker\_private\_ips | The worker nodes private ipv4 adresses |
+| swarm\_worker\_public\_ips | The worker nodes public ipv4 adresses |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -248,8 +248,8 @@ data "template_file" "ansible_inventory" {
 
   vars = {
     env                 = var.env
-    managers            = join("\n", local.manager_public_ip_list)
-    workers             = join("\n", aws_instance.worker.*.public_ip)
+    managers            = join("\n", var.connect_via_private_address ? aws_instance.manager.*.private_ip : local.manager_public_ip_list)
+    workers             = join("\n", var.connect_via_private_address ? aws_instance.worker.*.private_ip : aws_instance.worker.*.public_ip)
     manager_private_ips = join("\n", aws_instance.manager.*.private_ip)
     efs_host            = var.enable_efs ? "efs dns_name=${aws_efs_mount_target.main[0].dns_name}" : ""
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,24 +1,29 @@
+output "ansible_inventory" {
+  description = "Content of Ansible inventory"
+  value       = data.template_file.ansible_inventory.rendered
+}
+
 output "efs_dns_name" {
   description = "DNS name of the provisioned AWS EFS"
   value       = aws_efs_mount_target.main.*.dns_name
 }
 
-output "swarm_manager_ips" {
+output "swarm_manager_public_ips" {
   description = "The manager nodes public ipv4 adresses"
   value       = local.manager_public_ip_list
 }
 
-output "swarm_manager_ips_private" {
+output "swarm_manager_private_ips" {
   description = "The manager nodes private ipv4 adresses"
   value       = aws_instance.manager.*.private_ip
 }
 
-output "swarm_worker_ips" {
+output "swarm_worker_public_ips" {
   description = "The worker nodes public ipv4 adresses"
   value       = aws_instance.worker.*.public_ip
 }
 
-output "swarm_worker_ips_private" {
+output "swarm_worker_private_ips" {
   description = "The worker nodes private ipv4 adresses"
   value       = aws_instance.worker.*.private_ip
 }


### PR DESCRIPTION
- Private or  public IP of managers/workers on Ansible inventory based on `connect_via_private_address`.
- Output content of Ansible inventory.